### PR TITLE
Add default route for server

### DIFF
--- a/src/services/Server.js
+++ b/src/services/Server.js
@@ -114,6 +114,7 @@ module.exports = class Server extends EventEmitter {
       this._createDeliverEmitter(),
       this._createPackageJsonMiddleware(main),
       this._createBootJsMiddleware(appPath),
+      this._createDefaultRouteMiddleware(),
       ecstatic({root: appPath, showDir: false})
     ];
   }
@@ -157,6 +158,16 @@ module.exports = class Server extends EventEmitter {
     return (req, res, next) => {
       if (req.url === '/node_modules/tabris/boot.min.js') {
         return res.text(getBootJs(appPath, this._debugServer.getNewSessionId()));
+      }
+      next();
+    };
+  }
+
+  _createDefaultRouteMiddleware() {
+    return (req, res, next) => {
+      if (req.url === '/') {
+        const cliPackageJson = require('../../package.json');
+        return res.text(`Tabris.js CLI version ${cliPackageJson.version} is running`);
       }
       next();
     };

--- a/test/Server.test.js
+++ b/test/Server.test.js
@@ -130,6 +130,16 @@ describe('Server', function() {
         });
     });
 
+    it('shows a static message on the default route', function() {
+      writeFileSync(join(path, 'package.json'), '{"main": "unused.js"}');
+      return server.serve(path)
+        .then(() => fetch(`http://127.0.0.1:${server.port}/`))
+        .then(response => response.text())
+        .then(text => {
+          expect(text).to.match(/Tabris\.js CLI version .* is running/);
+        });
+    });
+
   });
 
 });


### PR DESCRIPTION
When showing the cli to new users I noticed that a few of them took the URL printed in the console and opened it in the browser presumably to test that it was working.  When doing so, the server returns a 200 but with a zero-length body, which doesn't inspire much confidence as the browser shows an empty white screen.  This used to show a directory index but had to be disabled due to eclipsesource/tabris-js#1472.

In order to instill some confidence I propose having the default route print a simple response `Tabris.js CLI version x.y.z is running`.  This should not have any ill effects unless an app happens to require `index.html` from the project root.  `index.js` or any other extension would work fine as ecstatic's `defaultExt` is set to `.html`.