### PR TITLE
Update to latest Cordova CLI version

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "chalk": "^1.1.3",
     "cli-progress": "^1.4.1",
     "commander": "^2.12.2",
-    "cordova": "6.5.0",
+    "cordova": "8.1.2",
     "ecstatic": "^2.1.0",
     "filewatcher": "^3.0.1",
     "fs-extra": "^4.0.0",


### PR DESCRIPTION
Enable usage of modern Cordova plugins utilizing previously unavailable
npm module features.

Note that plugin subdirectories[1] are not supported anymore and plugins
are required to provide a package.json.

Fix #49

[1]: https://cordova.apache.org/docs/en/6.x/reference/cordova-cli/index.html#plugin-spec

Change-Id: Ib32ae3b7a50d0b9ec8c7c653fd449daaf5eac45c