### PR TITLE
Provide friendlier error when boot.js is not found

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tabris-cli",
-  "version": "3.0.0-beta1",
+  "version": "3.0.0-beta2",
   "description": "Command line tool for Tabris.js",
   "dependencies": {
     "chalk": "^1.1.3",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "chalk": "^1.1.3",
     "cli-progress": "^1.4.1",
     "commander": "^2.12.2",
-    "cordova": "6.5.0",
+    "cordova": "8.1.2",
     "ecstatic": "^2.1.0",
     "filewatcher": "^3.0.1",
     "fs-extra": "^4.0.0",

--- a/src/services/Server.js
+++ b/src/services/Server.js
@@ -91,7 +91,7 @@ module.exports = class Server extends EventEmitter {
   _readTabrisPackageJson(appPath) {
     let packageJsonPath = join(appPath, 'node_modules', 'tabris', 'package.json');
     if (!existsSync(packageJsonPath)) {
-      throw new Error('No tabris module installed');
+      throw new Error('No tabris module installed; did you run npm install?');
     }
     return readJsonSync(packageJsonPath);
   }


### PR DESCRIPTION
It's possible to have a valid `package.json` but not to have run an `npm install`.  In this case, `tabris serve` still works, but throws a not very useful stack trace upon the first connection:

```plain
fs.js:646
  return binding.open(pathModule._makeLong(path), stringToFlags(flags), mode);
                 ^

Error: ENOENT: no such file or directory, open '/path/to/node_modules/tabris/boot.min.js'
    at Object.fs.openSync (fs.js:646:18)
    at fs.readFileSync (fs.js:551:33)
<snip>
```

This PR attempts to handle this use case better, and provide a suggestion to the user to fix the problem.