### PR TITLE
Improve error handling for IP address selection

### DIFF
--- a/test/ServerInfo.test.js
+++ b/test/ServerInfo.test.js
@@ -35,7 +35,7 @@ describe('ServerInfo', function() {
 
     it('returns address of wifi interface', async function() {
       let serverInfo = new ServerInfo({port: '8080', wsPort: '8081'}, ['127.0.0.1', '127.0.0.2']);
-      stub(serverInfo, 'getFirstWifiInterface').returns(Promise.resolve({address: '127.0.0.2'}));
+      stub(serverInfo, 'getFirstWifiInterface').returns(Promise.resolve('127.0.0.2'));
 
       let address = await serverInfo.selectAddressForQRCode();
 


### PR DESCRIPTION
* Gracefully handle errors in node-wifi (for #59)
* Properly handle IP address selection when no WiFi interfaces exist (for #45)
* Add a `<=` to the list of addresses to indicate which one is mapped to the QR code