### PR TITLE
Update to Node 18

### DIFF
--- a/src/services/Server.js
+++ b/src/services/Server.js
@@ -48,7 +48,7 @@ module.exports = class Server extends EventEmitter {
   static get externalAddresses() {
     const interfaces = os.networkInterfaces();
     return Object.keys(interfaces)
-      .map(key => interfaces[key].find(details => details.family === 'IPv4' && details.internal === false))
+      .map(key => interfaces[key].find(details => (details.family === 'IPv4' || details.family === 4) && details.internal === false))
       .filter(val => !!val)
       .map(iface => iface.address);
   }


### PR DESCRIPTION
NodeJS 18.0.0 changed os.networkInterfaces() so that the `family` property now returns a number instead of a string.