### PR TITLE
Fix order of config.xml siblings not preserved

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "cli-progress": "^1.4.1",
         "commander": "^2.12.2",
         "connect": "^3.7.0",
+        "fast-xml-parser": "^4.0.9",
         "filewatcher": "^3.0.1",
         "fs-extra": "^4.0.0",
         "generator-tabris-js": "^3.8.0",
@@ -28,7 +29,6 @@
         "tree-kill": "^1.2.2",
         "update-notifier": "^2.2.0",
         "ws": "^5.2.0",
-        "xml2js": "^0.4.17",
         "yauzl": "^2.8.0",
         "yeoman-environment": "^2.3.4"
       },
@@ -2118,6 +2118,21 @@
       "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
       "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
       "dev": true
+    },
+    "node_modules/fast-xml-parser": {
+      "version": "4.0.9",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.0.9.tgz",
+      "integrity": "sha512-4G8EzDg2Nb1Qurs3f7BpFV4+jpMVsdgLVuG1Uv8O2OHJfVCg7gcA53obuKbmVqzd4Y7YXVBK05oJG7hzGIdyzg==",
+      "dependencies": {
+        "strnum": "^1.0.5"
+      },
+      "bin": {
+        "fxparser": "src/cli/cli.js"
+      },
+      "funding": {
+        "type": "paypal",
+        "url": "https://paypal.me/naturalintelligence"
+      }
     },
     "node_modules/fd-slicer": {
       "version": "1.1.0",
@@ -4832,11 +4847,6 @@
       "integrity": "sha512-1HwIYD/8UlOtFS3QO3w7ey+SdSDFE4HRNLZoZRYVQefrOY3l17epswImeB1ijgJFQJodIaHcwkp3r/myBjFVbg==",
       "dev": true
     },
-    "node_modules/sax": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/sax/-/sax-1.1.4.tgz",
-      "integrity": "sha1-dLbTPJrh4AFRDxeakRaFiPGu2qk="
-    },
     "node_modules/scoped-regex": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/scoped-regex/-/scoped-regex-1.0.0.tgz",
@@ -5551,6 +5561,11 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/strnum": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-1.0.5.tgz",
+      "integrity": "sha512-J8bbNyKKXl5qYcR36TIO8W3mVGVHrmmxsd5PAItGkmyzwJvybiw2IVq5nqd0i4LSNSkB/sx9VHllbfFdr9k1JA=="
     },
     "node_modules/supports-color": {
       "version": "2.0.0",
@@ -6423,23 +6438,6 @@
       "integrity": "sha1-SWsswQnsqNus/i3HK2A8F8WHCtQ=",
       "engines": {
         "node": ">=4"
-      }
-    },
-    "node_modules/xml2js": {
-      "version": "0.4.19",
-      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.19.tgz",
-      "integrity": "sha512-esZnJZJOiJR9wWKMyuvSE1y6Dq5LCuJanqhxslH2bxM6duahNZ+HMpCLhBQGZkbX6xRf8x1Y2eJlgt2q3qo49Q==",
-      "dependencies": {
-        "sax": ">=0.6.0",
-        "xmlbuilder": "~9.0.1"
-      }
-    },
-    "node_modules/xml2js/node_modules/xmlbuilder": {
-      "version": "9.0.7",
-      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-9.0.7.tgz",
-      "integrity": "sha1-Ey7mPS7FVlxVfiD0wi35rKaGsQ0=",
-      "engines": {
-        "node": ">=4.0"
       }
     },
     "node_modules/xtend": {
@@ -8582,6 +8580,14 @@
       "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
       "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
       "dev": true
+    },
+    "fast-xml-parser": {
+      "version": "4.0.9",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.0.9.tgz",
+      "integrity": "sha512-4G8EzDg2Nb1Qurs3f7BpFV4+jpMVsdgLVuG1Uv8O2OHJfVCg7gcA53obuKbmVqzd4Y7YXVBK05oJG7hzGIdyzg==",
+      "requires": {
+        "strnum": "^1.0.5"
+      }
     },
     "fd-slicer": {
       "version": "1.1.0",
@@ -10754,11 +10760,6 @@
       "integrity": "sha512-1HwIYD/8UlOtFS3QO3w7ey+SdSDFE4HRNLZoZRYVQefrOY3l17epswImeB1ijgJFQJodIaHcwkp3r/myBjFVbg==",
       "dev": true
     },
-    "sax": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/sax/-/sax-1.1.4.tgz",
-      "integrity": "sha1-dLbTPJrh4AFRDxeakRaFiPGu2qk="
-    },
     "scoped-regex": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/scoped-regex/-/scoped-regex-1.0.0.tgz",
@@ -11357,6 +11358,11 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
       "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo="
+    },
+    "strnum": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-1.0.5.tgz",
+      "integrity": "sha512-J8bbNyKKXl5qYcR36TIO8W3mVGVHrmmxsd5PAItGkmyzwJvybiw2IVq5nqd0i4LSNSkB/sx9VHllbfFdr9k1JA=="
     },
     "supports-color": {
       "version": "2.0.0",
@@ -12045,22 +12051,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/xdg-basedir/-/xdg-basedir-3.0.0.tgz",
       "integrity": "sha1-SWsswQnsqNus/i3HK2A8F8WHCtQ="
-    },
-    "xml2js": {
-      "version": "0.4.19",
-      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.19.tgz",
-      "integrity": "sha512-esZnJZJOiJR9wWKMyuvSE1y6Dq5LCuJanqhxslH2bxM6duahNZ+HMpCLhBQGZkbX6xRf8x1Y2eJlgt2q3qo49Q==",
-      "requires": {
-        "sax": ">=0.6.0",
-        "xmlbuilder": "~9.0.1"
-      },
-      "dependencies": {
-        "xmlbuilder": {
-          "version": "9.0.7",
-          "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-9.0.7.tgz",
-          "integrity": "sha1-Ey7mPS7FVlxVfiD0wi35rKaGsQ0="
-        }
-      }
     },
     "xtend": {
       "version": "4.0.1",

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "cli-progress": "^1.4.1",
     "commander": "^2.12.2",
     "connect": "^3.7.0",
+    "fast-xml-parser": "^4.0.9",
     "filewatcher": "^3.0.1",
     "fs-extra": "^4.0.0",
     "generator-tabris-js": "^3.8.0",
@@ -22,7 +23,6 @@
     "tree-kill": "^1.2.2",
     "update-notifier": "^2.2.0",
     "ws": "^5.2.0",
-    "xml2js": "^0.4.17",
     "yauzl": "^2.8.0",
     "yeoman-environment": "^2.3.4"
   },

--- a/src/services/IndexHtml.js
+++ b/src/services/IndexHtml.js
@@ -1,4 +1,4 @@
-const xml2js = require('xml2js');
+const {XMLBuilder} = require('fast-xml-parser');
 
 const style = `
   body {
@@ -26,49 +26,46 @@ module.exports = class IndexHtml {
     const qrCode = await new Promise(resolve =>
       this.info.generateDataUrlQRCode(this.info.formatUrl(mainUrl), resolve)
     );
-    const builder = new xml2js.Builder({headless: true, preserveChildrenOrder: true});
     const multiAddress = this.info.externalURLs.length > 1;
     const data = {
       html: {
-        $: {lang: 'en'},
+        '@_lang': 'en',
         head: {
-          meta: {$: {charset: 'utf-8'}},
-          title: {_: 'Tabris.js CLI'},
-          style: {$: {type: 'text/css'}, _: style}
+          meta: {'@_charset': 'utf-8'},
+          title: 'Tabris.js CLI',
+          style: {'@_type': 'text/css', '#text': style},
         },
         body: {
-          h1: {_: 'Tabris.js CLI is running'},
+          h1: 'Tabris.js CLI is running',
           p: {
-            span: {
-              _: 'Scan the QR Code below using the',
-            },
+            span: 'Scan the QR Code below using the ',
             a: {
-              _: 'Tabris.js Developer App',
-              $: {
-                href: 'https://docs.tabris.com/latest/developer-app.html',
-                target: '_blank',
-                rel: 'noreferrer'
-              }
+              '@_href': 'https://docs.tabris.com/latest/developer-app.html',
+              '@_target': '_blank',
+              '@_rel': 'noreferrer',
+              '#text': 'Tabris.js Developer App'
             }
           },
-          img: {$:{src: qrCode}},
-          h3: {_: multiAddress ? 'Available URLs:' : 'URL:'},
+          img: {'@_src': qrCode},
+          h3: multiAddress ? 'Available URLs:' : 'URL:',
           ul: {
             li: this.info.externalURLs.map(url => ({
               code: {
-                $: {style: 'font-weight: bold'},
-                _: this.info.formatUrl(url)
+                '@_style': 'font-weight: bold',
+                '#text': this.info.formatUrl(url)
               },
               span: {
-                $: {style: 'font-style: italic'},
-                _: ((url.host === mainUrl.host) && multiAddress) ? '(QR Code)' : ''
+                '@_style': 'font-style: italic',
+                '#text': ((url.host === mainUrl.host) && multiAddress) ? '(QR Code)' : ''
               }
             }))
           }
         }
       }
     };
-    return '<!doctype html>\n' + builder.buildObject(data) + '\n';
+    const builder = new XMLBuilder({ignoreAttributes: false, suppressEmptyNode: true});
+    const result = builder.build(data);
+    return '<!doctype html>\n' + result + '\n';
   }
 
 };

--- a/test/ConfigXml.test.js
+++ b/test/ConfigXml.test.js
@@ -132,6 +132,14 @@ describe('ConfigXml', function() {
       expect(configXml.toString()).to.contain('<content src="app/foo/package.json"/>');
     });
 
+    it('adds src attribute to existing content element without src attribute', function() {
+      const configXml = new ConfigXml(createContent('<content />'));
+
+      configXml.adjustContentPath();
+
+      expect(configXml.toString()).to.contain('<content src="app/package.json"/>');
+    });
+
     it('returns context', function() {
       const configXml = new ConfigXml(createContent());
 


### PR DESCRIPTION
When sibling elements were declared in config.xml:

```xml
<edit-config file="*-Info.plist" target="..." mode="overwrite">
  <dict>
    <key>a</key><value>b</value>
    <key>c</key><value>d</value>
  </dict>
</edit-config>
```

... their order was not preserved by Tabris.js CLI when it edited
`config.xml` during build, e.g.:

```xml
<edit-config file="*-Info.plist" target="..." mode="overwrite">
  <dict>
    <key>a</key>
    <key>c</key>
    <value>b</value>
    <value>d</value>
  </dict>
</edit-config>
```

This corrupted configurations that rely on the order of siblings, like
Apple's Information Property Lists.

The XML parser previously used, `xml2js`, does support preserving the
order of siblings when parsing XML, however the enriched output it
creates in this case cannot be used to build XML back from it [1].
Migrate to `fast-xml-parser` which supports preserving element order
when both parsing and building XML.

[1]: https://github.com/Leonidas-from-XIV/node-xml2js/issues/622