### PR TITLE
Automatically run npm install before providing a platform

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tabris-cli",
-  "version": "3.8.0",
+  "version": "3.9.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "tabris-cli",
-      "version": "3.8.0",
+      "version": "3.9.0",
       "license": "BSD-3-Clause",
       "dependencies": {
         "boxen": "^4.2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tabris-cli",
-  "version": "3.8.0",
+  "version": "3.9.0",
   "description": "Command line tool for Tabris.js",
   "dependencies": {
     "boxen": "^4.2.0",

--- a/src/helpers/download.js
+++ b/src/helpers/download.js
@@ -1,5 +1,5 @@
 const https = require('https');
-const {createWriteStream, removeSync} = require('fs-extra');
+const {createWriteStream, removeSync, existsSync} = require('fs-extra');
 const EventEmitter = require('events');
 
 class FileDownloader extends EventEmitter {
@@ -37,6 +37,13 @@ class FileDownloader extends EventEmitter {
 
   _handleError(e = new Error('Error downloading file'), destination) {
     removeSync(destination);
+    // Windows sometimes fails silently on the first try:
+    if (existsSync(destination)) {
+      removeSync(destination);
+      if (existsSync(destination)) {
+        console.warn('Failed to delete ' + destination + ' trying again...');
+      }
+    }
     this.emit('error', e);
   }
 

--- a/src/helpers/proc.js
+++ b/src/helpers/proc.js
@@ -26,7 +26,7 @@ function _spawn({cmd, args, opts = {}}, {sync}) {
     shell: isWindows()
   }, opts));
   if (sync && child.status !== 0) {
-    throw new Error(childProcessExitedMessage(cmd, child.status));
+    throw new Error(childProcessExitedMessage(cmd, child.status || child.signal || child.error));
   }
   if (!sync) {
     childProcesses.push(child);

--- a/test/CLIHistory.test.js
+++ b/test/CLIHistory.test.js
@@ -8,6 +8,8 @@ const FILE_PATH = join(os.tmpdir(), 'cli_history.log');
 
 describe('CLI History', function() {
 
+  this.timeout(10000);
+
   let cliHistory = null;
 
   beforeEach(function() {
@@ -45,7 +47,7 @@ describe('CLI History', function() {
       cliHistory.addToHistory(`command ${i}`);
     }
     expect(cliHistory._history.length).to.equal(1000);
-  }).timeout(8000);
+  }).timeout(10000);
 
   it('remove old items when limit is exceeded', function() {
     for (let i = 1; i <= 2000; ++i) {
@@ -55,7 +57,7 @@ describe('CLI History', function() {
     const lastItem = cliHistory.currentHistory;
     expect(cliHistory._history[0]).to.equal('command 1001')
       && expect(lastItem).to.equal('command 2000');
-  }).timeout(8000);
+  });
 
   it('should be empty when previous item called more than limit', function() {
     for (let i = 1; i <= 2000; ++i) {
@@ -63,7 +65,7 @@ describe('CLI History', function() {
     }
     const currentItem = cliHistory.currentHistory;
     expect(currentItem).to.equal('');
-  }).timeout(8000);
+  });
 
   it('should be empty when next item called more than limit', function() {
     for (let i = 1; i <= 2000; ++i) {
@@ -71,6 +73,6 @@ describe('CLI History', function() {
     }
     const currentItem = cliHistory.currentHistory;
     expect(currentItem).to.equal('');
-  }).timeout(8000);
+  });
 
 });

--- a/test/CordovaCli.test.js
+++ b/test/CordovaCli.test.js
@@ -5,9 +5,8 @@ const proc = require('../src/helpers/proc');
 const {join} = require('path');
 const {expect, stub, restore, match} = require('./test');
 const CordovaCli = require('../src/services/CordovaCli');
-const {sep} = require('path');
 
-const CORDOVA = `path${sep}cordova`;
+const CORDOVA = 'path/cordova';
 
 describe('CordovaCli', function() {
 

--- a/test/PlatformProvider.test.js
+++ b/test/PlatformProvider.test.js
@@ -1,4 +1,4 @@
-const {mkdirsSync, readFileSync, readdirSync} = require('fs-extra');
+const {mkdirsSync, readFileSync, readdirSync, existsSync} = require('fs-extra');
 const {join} = require('path');
 const https = require('https');
 const yazl = require('yazl');
@@ -83,6 +83,11 @@ describe('PlatformProvider', function() {
         expect(children).to.deep.equal([name]);
       });
 
+      it('runs npm install if needed', async function() {
+        await provider.getPlatform({name, version});
+        expect(existsSync(join(platformPath, 'package.json'))).to.be.true;
+      });
+
     });
 
     describe('when platform download returns error code', function() {
@@ -158,6 +163,7 @@ function fakeResponse(statusCode) {
 function createPlatformResponseStream(statusCode) {
   const zipFile = new yazl.ZipFile();
   zipFile.addBuffer(Buffer.from('hello'), 'tabris-bar/foo.file');
+  zipFile.addBuffer(Buffer.from('{}'), 'tabris-bar/package.json');
   zipFile.end();
   zipFile.outputStream.statusCode = statusCode;
   zipFile.outputStream.headers = {'content-length': 1000};

--- a/test/pathCompleter.test.js
+++ b/test/pathCompleter.test.js
@@ -1,5 +1,5 @@
 const {writeFileSync, readdirSync, statSync} = require('fs-extra');
-const {join} = require('path');
+const {join, sep} = require('path');
 const temp = require('temp');
 const {expect, restore} = require('./test');
 const {pathCompleterSync} = require('../src/services/pathCompleter');
@@ -23,7 +23,7 @@ describe('pathCompleter', function() {
   });
 
   it('suggests contents of current working directory when ./ as path given', () => {
-    const [suggestions] = pathCompleterSync('./');
+    const [suggestions] = pathCompleterSync('.' + sep);
 
     expect(suggestions).to.deep.equal(readdirSync('.').map(appendSlashToDirectoryNames));
   });
@@ -32,7 +32,7 @@ describe('pathCompleter', function() {
     const [suggestions] = pathCompleterSync(folderPath);
 
     expect(suggestions.length).to.equal(1);
-    expect(suggestions[0]).to.equal(folderPath + '/');
+    expect(suggestions[0]).to.equal(folderPath + sep);
   });
 
   it('suggests same file path when file path given', () => {
@@ -47,7 +47,7 @@ describe('pathCompleter', function() {
   it('does not suggest anything when file path with / suffix given', () => {
     const barFilePath = join(folderPath, 'bar');
     writeFileSync(barFilePath, '');
-    const [suggestions] = pathCompleterSync(barFilePath + '/');
+    const [suggestions] = pathCompleterSync(barFilePath + sep);
 
     expect(suggestions.length).to.equal(0);
   });
@@ -55,7 +55,7 @@ describe('pathCompleter', function() {
   it('suggests files in directory when directory path with / suffix given', () => {
     const barFilePath = join(folderPath, 'bar');
     writeFileSync(barFilePath, '');
-    const [suggestions] = pathCompleterSync(folderPath + '/');
+    const [suggestions] = pathCompleterSync(folderPath + sep);
 
     expect(suggestions.length).to.equal(1);
     expect(suggestions[0]).to.equal(barFilePath);
@@ -77,4 +77,4 @@ describe('pathCompleter', function() {
 
 });
 
-const appendSlashToDirectoryNames = dir => dir + (statSync(dir).isDirectory() ? '/' : '');
+const appendSlashToDirectoryNames = dir => dir + (statSync(dir).isDirectory() ? sep : '');


### PR DESCRIPTION
Some cordova, npm/node and platform combinations do not automatically
install dependencies anymore before the platform is added to a project.
This does it explicitly.