### PR TITLE
🐛 Install missing platform dependencies

### DIFF
--- a/src/services/PlatformProvider.js
+++ b/src/services/PlatformProvider.js
@@ -25,7 +25,7 @@ module.exports = class PlatformProvider {
     const hasNodeModules = fs.pathExistsSync(join(path, 'node_modules'));
     if (hasPackageJson && !hasNodeModules) {
       log.command('Installing platform dependencies');
-      proc.spawnSync('npm', ['install', '--production'], {cwd: normalize(path)});
+      proc.spawnSync('npm', ['install'], {cwd: normalize(path)});
     }
     return path;
   }


### PR DESCRIPTION
As of Node.js 16, platform dependencies are no longer installed by Cordova automatically. The Cordova build uses some platform dependencies declared as `devDependencies` at runtime, such as `cordova-js`, causing the build to fail when using Node.js 16. Therefore, install all and not only production dependencies of the platform.